### PR TITLE
Add plot refinements, control fit progress output

### DIFF
--- a/xijafit/fit.py
+++ b/xijafit/fit.py
@@ -10,6 +10,7 @@ import re
 import logging
 import io
 import os
+import sys
 
 try:
     from ipywidgets import widgets
@@ -117,14 +118,20 @@ class XijaFit(object):
         self.sherpa_logger.setLevel(logging.INFO)
 
         self.log_capture_string = io.StringIO()
-        ch = logging.StreamHandler(self.log_capture_string)
+        if quiet == True:
+            ch = logging.StreamHandler(self.log_capture_string)
+        else:
+            ch = logging.StreamHandler(sys.stdout)
         ch.setLevel(logging.INFO)
         formatter = logging.Formatter('[%(levelname)s] (%(processName)-10s) %(message)s')
         ch.setFormatter(formatter)
         self.fit_logger.addHandler(ch)
 
         self.sherpa_log_capture_string = io.StringIO()
-        sch = logging.StreamHandler(self.sherpa_log_capture_string)
+        if quiet == True:
+            sch = logging.StreamHandler(self.sherpa_log_capture_string)
+        else:
+            sch = logging.StreamHandler(sys.stdout)
         sch.setLevel(logging.INFO)
         sformatter = logging.Formatter('[%(levelname)s] (%(processName)-10s) %(message)s')
         sch.setFormatter(sformatter)
@@ -363,7 +370,7 @@ class XijaFit(object):
             elif re.match(p2, par.full_name):
                 pass
             else:
-                par['frozen'] = False
+                par['frozen'] = Falseballbal
 
     def thaw_param(self, param):
         """Thaw specific parameter.


### PR DESCRIPTION
This PR adds the following plot refinements:
 - Ability to "bin" 1% and 99% error bounds by a user defined value in the temperature vs error scatterplot
 - 1% and 99% error bounds are now shown for bins as long as 20 or more datapoints exist in the particular bin, instead of requiring 200 datapoints or more
 - Numeric values for the 1%, 16%, 50%, 84%, and 99% quantiles are defined in the error histogram
 - Vertical lines are added for the 16%, 50%, and 84% quantiles in the error histogram
 - The maximum and minimum lines and labels are only printed if these values fall 1F or more within the x axis bounds of the error histogram plot

This PR adds the following change to the XijaFit class:
 - Ability to optionally send fit progress output directly to stdout instead of always suppressing this output by setting the `quiet=False` keyword