### PR TITLE
Add MD5 Watermark to Dashboards

### DIFF
--- a/xijafit/__init__.py
+++ b/xijafit/__init__.py
@@ -1,4 +1,5 @@
 from .fit import *
+from .dashboard import *
 
 __version__ = '0.7'
 

--- a/xijafit/dashboard.py
+++ b/xijafit/dashboard.py
@@ -159,13 +159,11 @@ def run_model(msid, t0, t1, model_spec_file, init={}):
         model_specs = load_model_specs()
         init = {'1dpamzt': 35., 'dpa0': 35., 'eclipse': False, 'roll': 0, 'vid_board': True, 'pitch':155,
                 'clocking': True, 'fep_count': 5, 'ccd_count': 5, 'sim_z': 100000}
-        model = setup_model('1dpamzt', '2019:001:00:00:00', '2019:010:00:00:00', model_specs['1dpamzt'], init)
+        model = run_model('1dpamzt', '2019:001:00:00:00', '2019:010:00:00:00', 'dpa_spec.json', init)
 
     Notes:
 
-     - This does not run the model, only sets up the model to be run.
-     - Any parameters not specified in `init` will either need to be pulled from telemetry or explicitly defined \
-     outside of this function before running the model.
+     - Any parameters not specified in `init` will need to be pulled from telemetry
 
     """
 

--- a/xijafit/dashboard.py
+++ b/xijafit/dashboard.py
@@ -182,7 +182,7 @@ def run_model(msid, t0, t1, model_spec_file, init={}):
     return model, model_spec_md5
 
 
-def watermarked_dashboard(model_spec_file, t0, t1, init={}, modelname='PSMC', msid='1pdeaat', errorplotlimits=None,
+def make_dashboard(model_spec_file, t0, t1, init={}, modelname='PSMC', msid='1pdeaat', errorplotlimits=None,
                           yplotlimits=None, bin_size=None, fig=None, savefig=True, legend_loc='best'):
     """ Generate a watermarked Xija model dashboard
 

--- a/xijafit/dashboard.py
+++ b/xijafit/dashboard.py
@@ -186,8 +186,23 @@ def run_model(msid, t0, t1, model_spec_file, init={}):
 
 def watermarked_dashboard(model_spec_file, t0, t1, modelname='PSMC', msid='1pdeaat', errorplotlimits=None,
                           yplotlimits=None, bin_size=None, fig=None, savefig=True, legend_loc='best'):
-    """
+    """ Generate a watermarked Xija model dashboard
 
+    :param model_spec_file: File location for Xija model definition
+    :param t0: Start Time (seconds or HOSC date string)
+    :param t1: Stop Time (seconds or HOSC date string)
+    :param modelname: Name of model (e.g. "ACA")
+    :param msid: msid name (e.g. "aacccdpt")
+    :param errorplotlimits: list or tuple of min and max x axis plot boundaries for both righthand
+           plots (optional)
+    :param yplotlimits: list or tuple of min and max y axis plot boundaries for both top half
+           plots (optional)
+    :param bin_size: int or float of desired bin size for 1% and 99% quantile calculations for scatter plot,
+           defaults to using telemetry count values if bin_size is left as None (optional)
+    :param fig:  Figure object to use, if None, a new figure object is generated (optional)
+    :param savefig: Option to automatically save the figure image (optional)
+    :param legend_loc: value to be passed to the 'loc' keyword in the  matplotlib pyplot legend
+           method, if None, then no legend is displayed (optional)
     """
 
     model_object, md5_hash = run_model(msid, t0, t1, model_spec_file, init={})
@@ -203,11 +218,11 @@ def watermarked_dashboard(model_spec_file, t0, t1, modelname='PSMC', msid='1pdea
 
     dashboard(prediction, telem, times, model_limits, modelname=modelname, msid=msid, errorplotlimits=errorplotlimits,
               yplotlimits=yplotlimits, bin_size=bin_size, fig=fig, savefig=savefig, legend_loc=legend_loc,
-              watermark=md5_hash)
+              md5_string=md5_hash)
 
 
 def dashboard(prediction, tlm, times, limits, modelname='PSMC', msid='1pdeaat', errorplotlimits=None, yplotlimits=None,
-              bin_size=None, fig=None, savefig=True, legend_loc='best', watermark=None):
+              bin_size=None, fig=None, savefig=True, legend_loc='best', md5_string=None):
     """ Plot Xija model dashboard.
 
     :param prediction: model prediction
@@ -227,6 +242,7 @@ def dashboard(prediction, tlm, times, limits, modelname='PSMC', msid='1pdeaat', 
     :param savefig: Option to automatically save the figure image (optional)
     :param legend_loc: value to be passed to the 'loc' keyword in the  matplotlib pyplot legend
            method, if None, then no legend is displayed (optional)
+    :param md5_string: MD5 hash of model file
 
     Note: prediction, tlm, and times must all have the same number of values.
 
@@ -266,8 +282,8 @@ def dashboard(prediction, tlm, times, limits, modelname='PSMC', msid='1pdeaat', 
     else:
         fig.clf()
 
-    if watermark is not None:
-        fig.text(0.01, 0.96, 'MD5: ' + watermark, fontsize=14, color=[0.5, 0.5, 0.5], horizontalalignment='left')
+    if md5_string is not None:
+        fig.text(0.01, 0.96, 'MD5: ' + md5_string, fontsize=14, color=[0.5, 0.5, 0.5], horizontalalignment='left')
 
     # ---------------------------------------------------------------------------------------------
     # Axis 1 - Model and Telemetry vs Time

--- a/xijafit/dashboard.py
+++ b/xijafit/dashboard.py
@@ -238,6 +238,8 @@ def make_dashboard(model_spec_file, t0, t1, init={}, modelname='PSMC', msid='1pd
               yplotlimits=yplotlimits, bin_size=bin_size, fig=fig, savefig=savefig, legend_loc=legend_loc,
               md5_string=md5_hash)
 
+    return model_object
+
 
 def dashboard(prediction, tlm, times, limits, modelname='PSMC', msid='1pdeaat', errorplotlimits=None, yplotlimits=None,
               bin_size=None, fig=None, savefig=True, legend_loc='best', md5_string=None):

--- a/xijafit/dashboard.py
+++ b/xijafit/dashboard.py
@@ -184,13 +184,14 @@ def run_model(msid, t0, t1, model_spec_file, init={}):
     return model, model_spec_md5
 
 
-def watermarked_dashboard(model_spec_file, t0, t1, modelname='PSMC', msid='1pdeaat', errorplotlimits=None,
+def watermarked_dashboard(model_spec_file, t0, t1, init={}, modelname='PSMC', msid='1pdeaat', errorplotlimits=None,
                           yplotlimits=None, bin_size=None, fig=None, savefig=True, legend_loc='best'):
     """ Generate a watermarked Xija model dashboard
 
     :param model_spec_file: File location for Xija model definition
     :param t0: Start Time (seconds or HOSC date string)
     :param t1: Stop Time (seconds or HOSC date string)
+    :param init: Dictionary of Xija model initialization parameters, can be empty (e.g. {'1dpamzt': 35., 'dpa0': 35.})
     :param modelname: Name of model (e.g. "ACA")
     :param msid: msid name (e.g. "aacccdpt")
     :param errorplotlimits: list or tuple of min and max x axis plot boundaries for both righthand
@@ -203,9 +204,10 @@ def watermarked_dashboard(model_spec_file, t0, t1, modelname='PSMC', msid='1pdea
     :param savefig: Option to automatically save the figure image (optional)
     :param legend_loc: value to be passed to the 'loc' keyword in the  matplotlib pyplot legend
            method, if None, then no legend is displayed (optional)
+
     """
 
-    model_object, md5_hash = run_model(msid, t0, t1, model_spec_file, init={})
+    model_object, md5_hash = run_model(msid, t0, t1, model_spec_file, init=init)
     msiddata = model_object.get_comp(msid)
     prediction = msiddata.mvals.astype(np.float64)
     times = msiddata.times.astype(np.float64)


### PR DESCRIPTION
This PR adds the ability to generate a watermarked dashboard. 

The `dashboard` method is modified to accept an md5 string, which will be added to the top left corner of the dashboard; this update is backwards compatible. 

A new method named `watermarked_dashboard` is added that calculates the md5 sum of a model file, runs the model to generate predictive results, and uses these data to generate a watermarked dashboard. This new function is intended to be the primary method by which new models are evaluated to ensure the correct md5 sum is displayed.